### PR TITLE
Merge colomoto-docker-base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,15 +97,15 @@ RUN AUTO_UPDATE=1 conda install --no-update-deps -y \
         r-boolnet=2.1.5 \
     && conda clean -y --all && rm -rf /opt/conda/pkgs
 
-# Tier 3: tools with frequent updates (>4/year)
+# Tier 3: tools with frequent updates (>4/year) or lightweight and thin dependencies
 RUN AUTO_UPDATE=1 conda install --no-update-deps -y \
         conda-forge::boolean.py=3.7=py_0 \
+        casq=0.7.4=py_1 \
         colomoto_jupyter=0.6.3=py_0 \
         ginsim-python=0.4.2=py_0 \
         mpbn=1.2=py_0 \
         pymaboss=0.7.11=py_0 \
         pypint=1.6.0=py_0 \
-        casq=0.7.4=py_1 \
     && conda clean -y --all && rm -rf /opt/conda/pkgs
 
 COPY validate.sh /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,7 @@ RUN conda install --no-update-deps -y \
 # - insert it in alphabetic order of package name
 
 # Tier 1: tools with rare updates (0-1/year) and thin dependencies
-RUN COLOMOTO_TOOLS=1 conda install --no-update-deps  -y \
+RUN AUTO_UPDATE=1 conda install --no-update-deps  -y \
         boolsim=1.2=0 \
         bns=1.3=0 \
         potassco::clingo=5.4.0=py37lua53hf484d3e_0 \
@@ -90,7 +90,7 @@ RUN COLOMOTO_TOOLS=1 conda install --no-update-deps  -y \
     && conda clean -y --all && rm -rf /opt/conda/pkgs
 
 # Tier 2: tools with regular updates (2-4/year)
-RUN COLOMOTO_TOOLS=1 conda install --no-update-deps -y \
+RUN AUTO_UPDATE=1 conda install --no-update-deps -y \
         ginsim=3.0.0b=11 \
         maboss=2.3.1=h6bb024c_0 \
         pint=2019.05.24=1 \
@@ -98,7 +98,7 @@ RUN COLOMOTO_TOOLS=1 conda install --no-update-deps -y \
     && conda clean -y --all && rm -rf /opt/conda/pkgs
 
 # Tier 3: tools with frequent updates (>4/year)
-RUN COLOMOTO_TOOLS=1 conda install --no-update-deps -y \
+RUN AUTO_UPDATE=1 conda install --no-update-deps -y \
         conda-forge::boolean.py=3.7=py_0 \
         colomoto_jupyter=0.6.3=py_0 \
         ginsim-python=0.4.2=py_0 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM debian:buster-20200414-slim
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 ENV PATH /opt/conda/bin:$PATH
 
-ARG USER=user
-ARG USER_UID=1000
-RUN useradd -u $USER_UID -m -d /notebook -s /bin/bash $USER
+ARG NB_USER=user
+ARG NB_UID=1000
+RUN useradd -u $NB_UID -m -d /notebook -s /bin/bash $NB_USER
 
 EXPOSE 8888
 WORKDIR /notebook
@@ -114,10 +114,10 @@ COPY bin/* /usr/bin/
 ##
 # Notebooks
 ##
-COPY --chown=$USER:$USER tutorials /notebook/tutorials
-COPY --chown=$USER:$USER usecases/*.ipynb /notebook/usecases/
+COPY --chown=$NB_USER:$NB_USER tutorials /notebook/tutorials
+COPY --chown=$NB_USER:$NB_USER usecases/*.ipynb /notebook/usecases/
 
-USER $USER
+USER $NB_USER
 
 RUN mkdir -p /notebook/.local/lib/python3.7/site-packages && \
     mkdir /notebook/persistent &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,75 @@
-FROM colomoto/colomoto-docker-base:py37-openjdk8-20200421
+FROM debian:buster-20200414-slim
 
-USER root
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+ENV PATH /opt/conda/bin:$PATH
+
+ARG USER=user
+ARG USER_UID=1000
+RUN useradd -u $USER_UID -m -d /notebook -s /bin/bash $USER
+
+EXPOSE 8888
+WORKDIR /notebook
+ENTRYPOINT ["/usr/bin/tini", "--", "colomoto-env"]
+CMD ["colomoto-nb", "--NotebookApp.token="]
+
+##
+## distribution packages
+##
+RUN apt-get update --fix-missing && \
+    mkdir /usr/share/man/man1 && touch /usr/share/man/man1/rmid.1.gz.dpkg-tmp && \
+    apt-get install -y --no-install-recommends \
+        bzip2 \
+        ca-certificates \
+        wget \
+        libxrender1 libice6 libxext6 libsm6 \
+        && \
+    apt clean -y && \
+    rm -rf /var/lib/apt/lists/*
+
+#
+# tini for avoiding zombie processes (useless with Docker 1.13)
+#
+RUN TINI_VERSION="0.19.0" && \
+    wget --quiet https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini_${TINI_VERSION}-amd64.deb && \
+    dpkg -i tini_${TINI_VERSION}-amd64.deb && \
+    rm *.deb
+
+#
+# base conda environment
+#
+# package versions in this section are not pinned unless necessary
+#
+RUN CONDA_VERSION="py37_4.8.2" && \
+    echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
+    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh -O ~/miniconda.sh && \
+    /bin/bash ~/miniconda.sh -b -p /opt/conda && \
+    rm ~/miniconda.sh && \
+    conda config --set auto_update_conda False && \
+    conda config --add channels conda-forge && \
+    conda config --add channels colomoto && \
+    conda install --no-update-deps -y \
+        -c colomoto/label/fake \
+        openjdk=8.0.144 \
+        pyqt && \
+    rm /opt/conda/jre/src.zip && \
+    conda clean -y --all && rm -rf /opt/conda/pkgs
+
+# notebook dependencies
+RUN conda install --no-update-deps -y \
+        libgfortran \
+        ipywidgets \
+        'matplotlib>=1.3.1' \
+        networkx \
+        nomkl \
+        notebook \
+        pandas \
+        pydot \
+        'pygraphviz>=1.5' \
+        rpy2 \
+        seaborn \
+        && \
+    conda clean -y --all && rm -rf /opt/conda/pkgs
+
 
 # IMPORTANT: DO NOT UPDATE PACKAGE VERSIONS MANUALLY
 
@@ -10,8 +79,8 @@ USER root
 # - choose the appropriate install tier depending on its expected frequency update
 # - insert it in alphabetic order of package name
 
-# Tier 1: tools with rare updates (0-1/year)
-RUN conda install --no-update-deps  -y \
+# Tier 1: tools with rare updates (0-1/year) and thin dependencies
+RUN COLOMOTO_TOOLS=1 conda install --no-update-deps  -y \
         boolsim=1.2=0 \
         bns=1.3=0 \
         potassco::clingo=5.4.0=py37lua53hf484d3e_0 \
@@ -21,7 +90,7 @@ RUN conda install --no-update-deps  -y \
     && conda clean -y --all && rm -rf /opt/conda/pkgs
 
 # Tier 2: tools with regular updates (2-4/year)
-RUN conda install --no-update-deps -y \
+RUN COLOMOTO_TOOLS=1 conda install --no-update-deps -y \
         ginsim=3.0.0b=11 \
         maboss=2.3.1=h6bb024c_0 \
         pint=2019.05.24=1 \
@@ -29,7 +98,7 @@ RUN conda install --no-update-deps -y \
     && conda clean -y --all && rm -rf /opt/conda/pkgs
 
 # Tier 3: tools with frequent updates (>4/year)
-RUN conda install --no-update-deps -y \
+RUN COLOMOTO_TOOLS=1 conda install --no-update-deps -y \
         conda-forge::boolean.py=3.7=py_0 \
         colomoto_jupyter=0.6.3=py_0 \
         ginsim-python=0.4.2=py_0 \
@@ -40,15 +109,15 @@ RUN conda install --no-update-deps -y \
     && conda clean -y --all && rm -rf /opt/conda/pkgs
 
 COPY validate.sh /usr/local/bin/
-
+COPY bin/* /usr/bin/
 
 ##
 # Notebooks
 ##
-COPY --chown=user:user tutorials /notebook/tutorials
-COPY --chown=user:user usecases/*.ipynb /notebook/usecases/
+COPY --chown=$USER:$USER tutorials /notebook/tutorials
+COPY --chown=$USER:$USER usecases/*.ipynb /notebook/usecases/
 
-USER user
+USER $USER
 
 RUN mkdir -p /notebook/.local/lib/python3.7/site-packages && \
     mkdir /notebook/persistent &&\
@@ -67,4 +136,3 @@ LABEL org.label-schema.build-date=$BUILD_DATETIME \
     org.label-schema.vcs-ref=$SOURCE_COMMIT \
     org.label-schema.vcs-url="https://github.com/colomoto/colomoto-docker" \
     org.label-schema.schema-version="1.0"
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update --fix-missing && \
         bzip2 \
         ca-certificates \
         wget \
-        libxrender1 libice6 libxext6 libsm6 \
+        openjdk-11-jre-headless \
         && \
     apt clean -y && \
     rm -rf /var/lib/apt/lists/*
@@ -49,9 +49,8 @@ RUN CONDA_VERSION="py37_4.8.2" && \
     conda config --add channels colomoto && \
     conda install --no-update-deps -y \
         -c colomoto/label/fake \
-        openjdk=8.0.144 \
+        openjdk \
         pyqt && \
-    rm /opt/conda/jre/src.zip && \
     conda clean -y --all && rm -rf /opt/conda/pkgs
 
 # notebook dependencies

--- a/bin/colomoto-env
+++ b/bin/colomoto-env
@@ -1,0 +1,3 @@
+#!/bin/bash
+source activate root
+"${@}"

--- a/bin/colomoto-nb
+++ b/bin/colomoto-nb
@@ -1,0 +1,2 @@
+#!/bin/bash
+jupyter-notebook --no-browser --ip=* --port 8888 --ip 0.0.0.0 "${@}"

--- a/hooks/release_changes.py
+++ b/hooks/release_changes.py
@@ -2,7 +2,7 @@ import json
 import os
 import re
 
-x = re.compile(r"^RUN\s+AUTO_UPDATE=1\b((?:.+\\\n)*.+[^\\]$)", re.M)
+x = re.compile(r"^RUN\b((?:.+\\\n)*.+[^\\]$)", re.M)
 y = re.compile(r"(?<=conda\sinstall\b)([^&]+)", re.S|re.M)
 c = re.compile(r"-c\s([^\s]+)")
 w = re.compile(r"[^\\\s]+")
@@ -16,6 +16,8 @@ def get_pkgs(lines, cfg):
         if arg[0] == "-" or ignore_next or arg in ["nomkl"]:
             pass
         else:
+            if "=" not in arg:
+                return
             if "::" in arg:
                 arg = arg.split("::")[1]
             pkg = arg.split("=")[:2]

--- a/hooks/release_changes.py
+++ b/hooks/release_changes.py
@@ -2,7 +2,7 @@ import json
 import os
 import re
 
-x = re.compile(r"^RUN\b((?:.+\\\n)*.+[^\\]$)", re.M)
+x = re.compile(r"^RUN\s+COLOMOTO_TOOLS=1\b((?:.+\\\n)*.+[^\\]$)", re.M)
 y = re.compile(r"(?<=conda\sinstall\b)([^&]+)", re.S|re.M)
 c = re.compile(r"-c\s([^\s]+)")
 w = re.compile(r"[^\\\s]+")

--- a/hooks/release_changes.py
+++ b/hooks/release_changes.py
@@ -2,7 +2,7 @@ import json
 import os
 import re
 
-x = re.compile(r"^RUN\s+COLOMOTO_TOOLS=1\b((?:.+\\\n)*.+[^\\]$)", re.M)
+x = re.compile(r"^RUN\s+AUTO_UPDATE=1\b((?:.+\\\n)*.+[^\\]$)", re.M)
 y = re.compile(r"(?<=conda\sinstall\b)([^&]+)", re.S|re.M)
 c = re.compile(r"-c\s([^\s]+)")
 w = re.compile(r"[^\\\s]+")

--- a/update-n-freeze.py
+++ b/update-n-freeze.py
@@ -9,7 +9,7 @@ import re
 from urllib.request import urlopen
 from urllib.error import HTTPError
 
-x = re.compile(r"^RUN\b((?:.+\\\n)*.+[^\\]$)", re.M)
+x = re.compile(r"^RUN\s+COLOMOTO_TOOLS=1\b((?:.+\\\n)*.+[^\\]$)", re.M)
 y = re.compile(r"(?<=conda\sinstall\b)([^&]+)", re.S|re.M)
 c = re.compile(r"-c\s([^\s]+)")
 w = re.compile(r"[^\\\s]+")

--- a/update-n-freeze.py
+++ b/update-n-freeze.py
@@ -9,7 +9,7 @@ import re
 from urllib.request import urlopen
 from urllib.error import HTTPError
 
-x = re.compile(r"^RUN\s+COLOMOTO_TOOLS=1\b((?:.+\\\n)*.+[^\\]$)", re.M)
+x = re.compile(r"^RUN\s+AUTO_UPDATE=1\b((?:.+\\\n)*.+[^\\]$)", re.M)
 y = re.compile(r"(?<=conda\sinstall\b)([^&]+)", re.S|re.M)
 c = re.compile(r"-c\s([^\s]+)")
 w = re.compile(r"[^\\\s]+")


### PR DESCRIPTION
Having separate `colomoto-docker-base` image (https://github.com/colomoto/colomoto-docker-base) makes the maintenance workflow quite complicated. This PR merges the two Dockerfile so the colomoto Docker environment is self-contained.

The image can be tested using
```
colomoto-docker -V pr54
```

PR also includes
- switch to Debian headless OpenJDK 11 (#56)