### PR TITLE
Switch to openjdk11 base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM colomoto/colomoto-docker-base:py37-openjdk8-20200421
+FROM colomoto/colomoto-docker-base:openjdk11
 
 USER root
 


### PR DESCRIPTION
Switch to `openjdk11` base image for testing.

The image can be tested using
```
colomoto-docker -V pr59
```