### PR TITLE
Next image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,7 @@ RUN AUTO_UPDATE=1 conda install --no-update-deps  -y \
 # Tier 2: tools with regular updates (2-4/year)
 RUN AUTO_UPDATE=1 conda install --no-update-deps -y \
         ginsim=3.0.0b=12 \
-        maboss=2.3.2=h6bb024c_0 \
+        maboss=2.3.3=h6bb024c_0 \
         pint=2019.05.24=1 \
         r-boolnet=2.1.5 \
     && conda clean -y --all && rm -rf /opt/conda/pkgs
@@ -103,7 +103,7 @@ RUN AUTO_UPDATE=1 conda install --no-update-deps -y \
         colomoto_jupyter=0.6.4=py_0 \
         ginsim-python=0.4.2=py_0 \
         mpbn=1.2=py_0 \
-        pymaboss=0.7.12=py_0 \
+        pymaboss=0.7.16=py_0 \
         pypint=1.6.0=py_0 \
     && conda clean -y --all && rm -rf /opt/conda/pkgs
 


### PR DESCRIPTION
Candidate next image with updated tool versions.

You can try it using
```
colomoto-docker -V next
```

By default, the image will be released at the end of the month.
If you need a persistent tag before (e.g., for a finalized publication), please manifest yourself in a comment below or at https://gitter.im/colomoto/colomoto-docker and we will tag it right away.