### PR TITLE
Force jedi version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ RUN conda install --no-update-deps -y \
         libgfortran \
         imagemagick \
         ipywidgets \
+        'jedi<0.18' \
         matplotlib \
         networkx \
         nomkl \


### PR DESCRIPTION
Waiting for upstream fix, this PR enforce the correct version of the `jedi` `ipython` dependency (see #88).

The image can be tested using
```
colomoto-docker -V pr91
```

Fixes #88 