### PR TITLE
Update casq and the associated tutorial

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -121,7 +121,7 @@ RUN AUTO_UPDATE=1 conda install --no-update-deps -y \
         cabean-python=1.0=py_0 \
         caspo-control=1.0=py_0 \
         boolean.py=3.9+git_1=py_0 \
-        casq=0.9.11=py_0 \
+        casq=1.0.3=py_0 \
         colomoto_jupyter=0.8.2=py_0 \
         ginsim-python=0.4.3=py_0 \
         mpbn=1.6=py_0 \

--- a/tutorials/CaSQ/CaSQ_from_CellDesigner_to_GINsim.ipynb
+++ b/tutorials/CaSQ/CaSQ_from_CellDesigner_to_GINsim.ipynb
@@ -14,10 +14,7 @@
    "outputs": [],
    "source": [
     "import casq.celldesigner2qual as casq\n",
-    "from colomoto_jupyter import tabulate\n",
-    "\n",
-    "# debug messages are enabled by default\n",
-    "casq.logger.disable(\"casq\")"
+    "from colomoto_jupyter import tabulate"
    ]
   },
   {
@@ -26,12 +23,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Load and simplify a cell designer map\n",
-    "info, width, height = casq.read_celldesigner(\"Apoptosis_VS_SSA_AN.xml\")\n",
-    "casq.simplify_model(info)\n",
-    "\n",
-    "# Write the SBML file\n",
-    "casq.write_qual(\"Apoptosis_VS_SSA_AN.sbml\", info, width, height)"
+    "# Convert a cell designer map\n",
+    "casq.map_to_model(\"Apoptosis_VS_SSA_AN.xml\", \"Apoptosis_VS_SSA_AN.sbml\")"
    ]
   },
   {


### PR DESCRIPTION
Update the casq tutorial with a streamlined API

The image can be tested using
```
colomoto-docker -V pr<PULL REQUEST ID>
```
