### PR TITLE
Image mirroring on Zenodo

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   release:
     env:
-      IMAGE_BASENAME: colomoto/colomoto-docker
+      IMAGE_BASENAME: ${{vars.COLOMOTO_DOCKER_IMAGE}}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/dockerimage-next.yml
+++ b/.github/workflows/dockerimage-next.yml
@@ -8,8 +8,8 @@ on:
 jobs:
   validate-next:
     env:
-      IMAGE: colomoto/colomoto-docker:for-next
-      IMAGE_NEXT: colomoto/colomoto-docker:next
+      IMAGE: ${{vars.COLOMOTO_DOCKER_IMAGE}}:for-next
+      IMAGE_NEXT: ${{vars.COLOMOTO_DOCKER_IMAGE}}:next
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/mirror-ghcr.yml
+++ b/.github/workflows/mirror-ghcr.yml
@@ -1,4 +1,4 @@
-name: Mirror docker images
+name: Mirror docker images on GitHub
 
 on:
   repository_dispatch:

--- a/.github/workflows/mirror-ghcr.yml
+++ b/.github/workflows/mirror-ghcr.yml
@@ -23,8 +23,8 @@ jobs:
         env:
             REF: ${{ github.event.action }}
       - run: |
-          echo IMAGE=colomoto/colomoto-docker:${TAG} >> $GITHUB_ENV
-          echo GH_IMAGE=ghcr.io/colomoto/colomoto-docker:${TAG} >> $GITHUB_ENV
+          echo IMAGE=${{vars.COLOMOTO_DOCKER_IMAGE}}:${TAG} >> $GITHUB_ENV
+          echo GH_IMAGE=ghcr.io/${{vars.COLOMOTO_DOCKER_IMAGE}}:${TAG} >> $GITHUB_ENV
       - run: docker pull ${IMAGE}
       - run: docker tag $IMAGE $GH_IMAGE
       - name: Login to GitHub Packages

--- a/.github/workflows/mirror-zenodo.yml
+++ b/.github/workflows/mirror-zenodo.yml
@@ -1,5 +1,14 @@
 name: Mirror docker images on Zenodo
 
+#
+# Upload images on Zenodo using Donodo
+#
+# The environment variable vars.DONODO_FLAGS is used to add common options to Donodo;
+# currently --debug or --sandbox.
+# If --sandbox is specified, then ZENODO_TOKEN is set to secrets.ZENODO_SANDBOX_TOKEN
+# instead of secrets.ZENODO_TOKEN.
+#
+
 on:
   repository_dispatch:
     types:

--- a/.github/workflows/mirror-zenodo.yml
+++ b/.github/workflows/mirror-zenodo.yml
@@ -1,0 +1,47 @@
+name: Mirror docker images on Zenodo
+
+on:
+  repository_dispatch:
+    types:
+      - 'mirror-zenodo/*-*-*'
+      - 'mirrors/*-*-*'
+  push:
+    tags:
+      - '*-*-*'
+
+jobs:
+  mirror-zenodo:
+    name: Release on Zenodo
+    runs-on: ubuntu-latest
+    env:
+      DONODO_FLAGS : ${{vars.DONODO_FLAGS}}
+    steps:
+      - name: Checking if Zenodo sandbox is used
+        run: |
+          if [[ "$DONODO_FLAGS" =~ "--sandbox" ]]; then           
+            echo ZENODO_TOKEN=${{secrets.ZENODO_SANDBOX_TOKEN}} >> $GITHUB_ENV;
+            echo ZENODO_SANDBOX=1 >> $GITHUB_ENV;
+          else
+            echo ZENODO_TOKEN=${{secrets.ZENODO_TOKEN}} >> $GITHUB_ENV
+            echo ZENODO_SANDBOX=0 >> $GITHUB_ENV;
+          fi
+        shell: bash
+      - run:
+          echo TAG=${GITHUB_REF##*/} >> $GITHUB_ENV
+        if: github.event_name == 'push'
+      - run:
+          echo TAG=${REF##*/} >> $GITHUB_ENV
+        if: github.event_name == 'repository_dispatch'
+        env:
+            REF: ${{ github.event.action }}
+      - run:
+          echo IMAGE=${{vars.COLOMOTO_DOCKER_IMAGE}}:${TAG} >> $GITHUB_ENV
+      - name: Setup Donodo
+        uses: actions/setup-python@v5
+        with:
+            python-version: '3.12'
+      - run: pip install donodo
+      - name: Pulling Docker image ${{env.IMAGE}}
+        run: docker pull ${IMAGE}
+      - name: donodo ${{vars.DONODO_FLAGS}} push --auto-publish ${{env.IMAGE}}
+        run: donodo $DONODO_FLAGS push --auto-publish ${IMAGE}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - run: |
           TAG=${GITHUB_REF##*/}
           echo TAG=${TAG} >> $GITHUB_ENV
-          echo IMAGE=colomoto/colomoto-docker:${TAG} >> $GITHUB_ENV
+          echo IMAGE=${{vars.COLOMOTO_DOCKER_IMAGE}}:${TAG} >> $GITHUB_ENV
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - name: release info

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   validate:
     env:
-      IMAGE: colomoto/colomoto-docker:pr${{ github.event.pull_request.number }}
+      IMAGE: ${{vars.COLOMOTO_DOCKER_IMAGE}}:pr${{ github.event.pull_request.number }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:sid-20250224-slim
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
-ENV PATH /home/user/.local/bin:/opt/conda/bin:$PATH
+ENV PATH=/home/user/.local/bin:/opt/conda/bin:$PATH
 
 ARG NB_USER=user
 ARG NB_UID=1000
@@ -40,11 +40,12 @@ RUN TINI_VERSION="0.19.0" && \
 #
 # package versions in this section are not pinned unless necessary
 #
-RUN CONDA_VERSION="py312_25.1.1-2" && \
+RUN CONDA_VERSION="py312_25.5.1-0" && \
     echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     wget --quiet https://repo.continuum.io/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh -O ~/miniconda.sh && \
     /bin/bash ~/miniconda.sh -b -p /opt/conda && \
     rm ~/miniconda.sh && \
+    conda tos accept && \
     conda config --set auto_update_conda False && \
     conda config --append channels colomoto && \
     conda config --add channels conda-forge && \
@@ -117,12 +118,12 @@ RUN AUTO_UPDATE=1 conda install --no-update-deps  -y  \
         -c potassco -c bioasp \
         asprin=3.1.1=py_0 \
         boolsim=1.2=0 \
-        boolean.py=4.0+git_1=py_0 \
+        boolean.py=5.0=pyhd8ed1ab_0 \
         booleannet=1.2.8=py_0 \
         bns=1.3=h2bc3f7f_0 \
         cabean=1.0.0=0 \
         caspo=4.0.1=py_1 \
-        clingo=5.7.1=py312h3fd9d12_0 \
+        clingo=5.8.0=py312h3fd9d12_0 \
         erode-python=0.7.2=py_0 \
         ginsim=3.0.0b=13 \
         its=20210125=0 \
@@ -136,7 +137,7 @@ RUN AUTO_UPDATE=1 conda install --no-update-deps  -y  \
 RUN AUTO_UPDATE=1 conda install --no-update-deps -y \
         -c daemontus \
         biodivine_aeon=1.2.3=py312h9bf148f_0 \
-        maboss=2.6.1=he9e06a5_1 \
+        maboss=2.6.2=h656b026_1 \
         pyboolnet=3.0.16=py312_0 \
     && conda clean -y --all && rm -rf /opt/conda/pkgs
 
@@ -145,7 +146,7 @@ RUN AUTO_UPDATE=1 conda install --no-update-deps -y \
         -c creda \
         algorecell_types=1.0=py_0 \
         bns-python=0.2=py_0 \
-        bonesis=0.6.7=py_0 \
+        bonesis=0.6.8.1=py_0 \
         boon=1.28=py_0 \
         boolsim-python=0.5=py_0 \
         cabean-python=1.0=py_0 \


### PR DESCRIPTION
This PR add a workflow to upload images on Zenodo (or its sandbow) using Donodo.

The script is based on mirror-ghrc.yml. It requires to declare ZENODO_TOKEN (as a secret) and ZENODO_SANDBOX_TOKEN if the Zenodo's sandbox  is used.

 See also pauleve/donodo#3 and colomoto/colomoto-docker-py#2
