### PR TITLE
minor fix for optboolnet, tutorial to install gurobi license

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -142,7 +142,7 @@ RUN AUTO_UPDATE=1 conda install --no-update-deps -y \
         daemontus::biodivine_aeon=1.2.3=py312h9bf148f_0 \
         maboss=2.6.5=h656b026_1 \
         pyboolnet=3.0.16=py312_0 \
-        msolab::optboolnet=1.0.0=py_0 \
+        msolab::optboolnet=1.0.1=py_0 \
     && conda clean -y --all && rm -rf /opt/conda/pkgs
 
 # Tier 3: tools with frequent updates (>4/year) or lightweight with thin dependencies

--- a/tutorials/optboolnet/bladder_example.ipynb
+++ b/tutorials/optboolnet/bladder_example.ipynb
@@ -87,6 +87,34 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This package relies on a third-party mixed-integer programming solver `gurobi`. \n",
+    "The package can be installed via conda:\n",
+    "\n",
+    "```bash\n",
+    "conda install -c gurobi gurobi\n",
+    "```\n",
+    "By default, Gurobi is limited to small models. To solve large scale problems, you need to install the license (free for academic use) and set the `GRB_LICENSE_FILE` environment variable.\n",
+    "\n",
+    "(Unblock the following code after locating `gurobi.lic` license file in `/notebook` folder)\n",
+    "\n",
+    "For a CoLoMoTo Docker environment, consider a Web License Service (WLS) license file (See [Gurobi WLS documentation](https://support.gurobi.com/hc/en-us/articles/13232844297489-How-do-I-set-up-a-Web-License-Service-WLS-license) for details)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import os\n",
+    "\n",
+    "# os.environ[\"GRB_LICENSE_FILE\"] = \"/notebook/gurobi.lic\""
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},

--- a/tutorials/optboolnet/bladder_example.ipynb
+++ b/tutorials/optboolnet/bladder_example.ipynb
@@ -90,12 +90,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This package relies on a third-party mixed-integer programming solver `gurobi`. \n",
-    "The package can be installed via conda:\n",
+    "This package relies on a third-party mixed-integer programming solver `gurobi`, which is already installed on CoLoMoTo Docker \n",
     "\n",
-    "```bash\n",
-    "conda install -c gurobi gurobi\n",
-    "```\n",
     "By default, Gurobi is limited to small models. To solve large scale problems, you need to install the license (free for academic use) and set the `GRB_LICENSE_FILE` environment variable.\n",
     "\n",
     "(Unblock the following code after locating `gurobi.lic` license file in `/notebook` folder)\n",


### PR DESCRIPTION
[TIP]:  # ( PR including a tool: set the title above ^^ with the form "Include tool <TOOL NAME>" )

[NOTE]: # ( PR including a tool: provide a short description of the tool )

The image can be tested using
```
colomoto-docker -V pr<PULL REQUEST ID>
```

[NOTE]: # ( Checklist for including a new tool, remove if it is not appropriate )
## Checklist
[NOTE]: # ( Please go over all the following points. )
[NOTE]: # ( Remove any lines which don't apply. )
[NOTE]: # ( Uncheck missing items if you need help completing them )
- [x] The conda package is added in one of the 3 install section of `Dockerfile` **[REQUIRED]**
- [x] There is at least one tutorial notebook in `tutorials/{tool}` folder **[REQUIRED]**
- [x] Tutorial notebooks are referenced in `validate.sh` **[REQUIRED]**
- [x] Tool has `tools/{tool}.md` file (from `tools/TEMPLATE.md`) **[REQUIRED]**
